### PR TITLE
Delete MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,0 @@
-include doc/*.rst
-include doc/*.png
-include doc/*.gif
-include orbitf352123502N001_eph0.fits


### PR DESCRIPTION
Post 4.0 cleanup of packaging.  The old manifest was thwarting setuptools putting all the data files in the tarball.